### PR TITLE
特定のウォレットアプリのみ有効に変更（iOSのみ対応）

### DIFF
--- a/lib/src/components/modal_wallet_ios_page.dart
+++ b/lib/src/components/modal_wallet_ios_page.dart
@@ -40,82 +40,18 @@ class ModalWalletIOSPage extends StatelessWidget {
               ),
               Expanded(
                 child: ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: walletData.data!.length,
-                    itemBuilder: (context, index) {
-                      final wallet = walletData.data![index];
-                      return Stack(children: [
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 8),
-                          child: GestureDetector(
-                            onTap: () async {
-                              if (shouldEnable(wallet)) {
-                                walletCallback?.call(wallet);
-                                Utils.iosLaunch(wallet: wallet, uri: uri);
-                              }
-                            },
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                        vertical: 16),
-                                    child: Text(
-                                      wallet.name,
-                                      style: const TextStyle(
-                                        fontSize: 18,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                Container(
-                                  clipBehavior: Clip.hardEdge,
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(8),
-                                    boxShadow: [
-                                      BoxShadow(
-                                        color: Colors.grey.withOpacity(0.3),
-                                        blurRadius: 5,
-                                        spreadRadius: 2,
-                                      ),
-                                    ],
-                                  ),
-                                  child: CachedNetworkImage(
-                                    imageUrl:
-                                        'https://registry.walletconnect.org/logo/sm/${wallet.id}.jpeg',
-                                    height: 30,
-                                  ),
-                                ),
-                                const Padding(
-                                  padding: EdgeInsets.only(left: 8),
-                                  child: Icon(
-                                    Icons.arrow_forward_ios,
-                                    size: 20,
-                                    color: Colors.grey,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                        if (!shouldEnable(wallet))
-                          Container(
-                            width: double.infinity,
-                            padding: const EdgeInsets.symmetric(vertical: 16),
-                            color: Colors.black.withOpacity(0.8),
-                            child: const Center(
-                              child: Text(
-                                'Coming soon...',
-                                style: TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                    color: Colors.white),
-                              ),
-                            ),
-                          )
-                      ]);
-                    }),
+                  shrinkWrap: true,
+                  itemCount: walletData.data!.length,
+                  itemBuilder: (context, index) {
+                    final wallet = walletData.data![index];
+                    return Stack(
+                      children: [
+                        _buildItem(wallet),
+                        if (!shouldEnable(wallet)) _buildLayer()
+                      ],
+                    );
+                  },
+                ),
               ),
             ],
           );
@@ -154,4 +90,78 @@ class ModalWalletIOSPage extends StatelessWidget {
   }
 
   bool shouldEnable(Wallet wallet) => wallet.name == 'MetaMask';
+
+  Widget _buildItem(Wallet wallet) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: GestureDetector(
+        onTap: () async {
+          if (shouldEnable(wallet)) {
+            walletCallback?.call(wallet);
+            Utils.iosLaunch(wallet: wallet, uri: uri);
+          }
+        },
+        child: Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Text(
+                  wallet.name,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            Container(
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.3),
+                    blurRadius: 5,
+                    spreadRadius: 2,
+                  ),
+                ],
+              ),
+              child: CachedNetworkImage(
+                imageUrl:
+                    'https://registry.walletconnect.org/logo/sm/${wallet.id}.jpeg',
+                height: 30,
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.only(left: 8),
+              child: Icon(
+                Icons.arrow_forward_ios,
+                size: 20,
+                color: Colors.grey,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLayer() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      color: Colors.black.withOpacity(0.8),
+      child: const Center(
+        child: Text(
+          'Coming soon...',
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/components/modal_wallet_ios_page.dart
+++ b/lib/src/components/modal_wallet_ios_page.dart
@@ -44,58 +44,77 @@ class ModalWalletIOSPage extends StatelessWidget {
                     itemCount: walletData.data!.length,
                     itemBuilder: (context, index) {
                       final wallet = walletData.data![index];
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        child: GestureDetector(
-                          onTap: () async {
-                            walletCallback?.call(wallet);
-                            Utils.iosLaunch(wallet: wallet, uri: uri);
-                          },
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(vertical: 16),
-                                  child: Text(
-                                    wallet.name,
-                                    style: const TextStyle(
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.bold,
+                      return Stack(children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          child: GestureDetector(
+                            onTap: () async {
+                              if (shouldEnable(wallet)) {
+                                walletCallback?.call(wallet);
+                                Utils.iosLaunch(wallet: wallet, uri: uri);
+                              }
+                            },
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 16),
+                                    child: Text(
+                                      wallet.name,
+                                      style: const TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              Container(
-                                clipBehavior: Clip.hardEdge,
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(8),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: Colors.grey.withOpacity(0.3),
-                                      blurRadius: 5,
-                                      spreadRadius: 2,
-                                    ),
-                                  ],
+                                Container(
+                                  clipBehavior: Clip.hardEdge,
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(8),
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: Colors.grey.withOpacity(0.3),
+                                        blurRadius: 5,
+                                        spreadRadius: 2,
+                                      ),
+                                    ],
+                                  ),
+                                  child: CachedNetworkImage(
+                                    imageUrl:
+                                        'https://registry.walletconnect.org/logo/sm/${wallet.id}.jpeg',
+                                    height: 30,
+                                  ),
                                 ),
-                                child: CachedNetworkImage(
-                                  imageUrl:
-                                      'https://registry.walletconnect.org/logo/sm/${wallet.id}.jpeg',
-                                  height: 30,
+                                const Padding(
+                                  padding: EdgeInsets.only(left: 8),
+                                  child: Icon(
+                                    Icons.arrow_forward_ios,
+                                    size: 20,
+                                    color: Colors.grey,
+                                  ),
                                 ),
-                              ),
-                              const Padding(
-                                padding: EdgeInsets.only(left: 8),
-                                child: Icon(
-                                  Icons.arrow_forward_ios,
-                                  size: 20,
-                                  color: Colors.grey,
-                                ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
-                      );
+                        if (!shouldEnable(wallet))
+                          Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            color: Colors.black.withOpacity(0.8),
+                            child: const Center(
+                              child: Text(
+                                'Coming soon...',
+                                style: TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.white),
+                              ),
+                            ),
+                          )
+                      ]);
                     }),
               ),
             ],
@@ -122,11 +141,17 @@ class ModalWalletIOSPage extends StatelessWidget {
         final filter = <Wallet>[];
         for (final wallet in wallets) {
           if (await shouldShow(wallet)) {
-            filter.add(wallet);
+            if (shouldEnable(wallet)) {
+              filter.insert(0, wallet);
+            } else {
+              filter.add(wallet);
+            }
           }
         }
         return filter;
       },
     );
   }
+
+  bool shouldEnable(Wallet wallet) => wallet.name == 'MetaMask';
 }


### PR DESCRIPTION
### 内容
- MetaMaskのみ有効化
- 他のウォレットアプリに関しては、一旦Coming soon（無効化）
### 背景
- MetaMask以外のアプリで、署名から取得したwalletAddressが本来のと一致しない問題
- 原因
  - 署名メッセージの文字化けが関係している？
    - Rainbowにて、確認済み
### UI
<img src=https://user-images.githubusercontent.com/88795879/182629073-2f70e80e-d0ef-4444-94ab-b65791545790.jpeg height=800 width=400 />