### PR TITLE
Fix android iOS同様のUIに変更（Metamaskのみ）

### DIFF
--- a/lib/src/components/modal_main_page.dart
+++ b/lib/src/components/modal_main_page.dart
@@ -116,7 +116,7 @@ class _ModalContent extends StatelessWidget {
       if (Utils.isIOS) {
         return ModalWalletIOSPage(uri: uri, walletCallback: walletCallback);
       } else if (Utils.isAndroid) {
-        return ModalWalletAndroidPage(uri: uri);
+        return ModalWalletAndroidPage(uri: uri, walletCallback: walletCallback);
       } else {
         return ModalWalletDesktopPage(uri: uri, walletCallback: walletCallback);
       }

--- a/lib/src/components/modal_wallet_android_page.dart
+++ b/lib/src/components/modal_wallet_android_page.dart
@@ -1,20 +1,136 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/components/modal_main_page.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/models/wallet.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/store/wallet_store.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/utils/utils.dart';
 
 class ModalWalletAndroidPage extends StatelessWidget {
   const ModalWalletAndroidPage({
     required this.uri,
+    this.store = const WalletStore(),
+    this.walletCallback,
     Key? key,
   }) : super(key: key);
 
   final String uri;
+  final WalletStore store;
+  final WalletCallback? walletCallback;
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ElevatedButton(
-        onPressed: () => launchUrl(Uri.parse(uri)),
-        child: const Text('Connect'),
+    return FutureBuilder(
+      future: androidWallets(),
+      builder: (context, AsyncSnapshot<List<Wallet>> walletData) {
+        if (walletData.hasData) {
+          return Column(
+            children: [
+              const Padding(
+                padding: EdgeInsets.only(top: 16, bottom: 8),
+                child: Text(
+                  'Choose your preferred wallet',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.grey,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: walletData.data!.length,
+                  itemBuilder: (context, index) {
+                    final wallet = walletData.data![index];
+                    if (!shouldEnable(wallet)) return Container();
+                    return _buildItem(wallet);
+                  },
+                ),
+              ),
+            ],
+          );
+        } else {
+          return const Center(
+            child: CircularProgressIndicator(
+              color: Colors.grey,
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  Future<List<Wallet>> androidWallets() {
+    Future<bool> shouldShow(wallet) async =>
+        await Utils.openableLink(wallet.mobile.universal) ||
+        await Utils.openableLink(wallet.mobile.native) ||
+        await Utils.openableLink(wallet.app.android);
+
+    return store.load().then(
+      (wallets) async {
+        final filter = <Wallet>[];
+        for (final wallet in wallets) {
+          if (await shouldShow(wallet)) {
+            if (shouldEnable(wallet)) {
+              filter.insert(0, wallet);
+            } else {
+              filter.add(wallet);
+            }
+          }
+        }
+        return filter;
+      },
+    );
+  }
+
+  bool shouldEnable(Wallet wallet) => wallet.name == 'MetaMask';
+
+  Widget _buildItem(Wallet wallet) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: GestureDetector(
+        onTap: () async {
+          if (shouldEnable(wallet)) {
+            walletCallback?.call(wallet);
+            Utils.androidLaunch(wallet: wallet, uri: uri);
+          }
+        },
+        child: Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Text(
+                  wallet.name,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            Container(
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.3),
+                    blurRadius: 5,
+                    spreadRadius: 2,
+                  ),
+                ],
+              ),
+              child: CachedNetworkImage(
+                imageUrl:
+                    'https://registry.walletconnect.org/logo/sm/${wallet.id}.jpeg',
+                height: 30,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -39,6 +39,24 @@ class Utils {
     }
   }
 
+  static Future<void> androidLaunch({
+    required Wallet wallet,
+    required String uri,
+  }) async {
+    if (await openableLink(wallet.mobile.universal)) {
+      await launchUrl(
+        convertToWcLink(appLink: wallet.mobile.universal!, wcUri: uri),
+        mode: LaunchMode.externalApplication,
+      );
+    } else if (await openableLink(wallet.mobile.native)) {
+      await launchUrl(
+        convertToWcLink(appLink: wallet.mobile.native!, wcUri: uri),
+      );
+    } else if (await openableLink(wallet.app.android)) {
+      await launchUrl(Uri.parse(wallet.app.android!));
+    }
+  }
+
   static Future<void> desktopLaunch({
     required Wallet wallet,
     required String uri,


### PR DESCRIPTION
### 内容
- Metamaskのみにandroidも対応
  - iOSのコード参考
  - iOSとの変更部分はコメント記載
- Metamaskがインストールされていない場合、Google play storeに遷移
### 背景
- どのウォレットアプリでも対応しているように感じる
- ウォレットアプリがインストールされていないとボタン押しても反応しない
### UI
- 変更前
 <img src=https://user-images.githubusercontent.com/88795879/191187997-12279d7a-0800-46da-b576-415f20f4790a.png width=150 /><img src=https://user-images.githubusercontent.com/88795879/191187980-dec9420e-2fbd-45b4-9595-715ab09e4bc1.png width=150 />
- 変更後
  - Metamaskがある場合
<img src=https://user-images.githubusercontent.com/88795879/191187997-12279d7a-0800-46da-b576-415f20f4790a.png width=150 /><img src=https://user-images.githubusercontent.com/88795879/191187980-dec9420e-2fbd-45b4-9595-715ab09e4bc1.png width=150 /><img src=https://user-images.githubusercontent.com/88795879/191188972-29dd800d-40d7-4d93-bb18-5c14c098b005.png width=150 /><img src=https://user-images.githubusercontent.com/88795879/191188002-4c3b795d-b6fa-4275-900c-311df6f72c3b.png width=150 /><img src=https://user-images.githubusercontent.com/88795879/191188965-5537be47-3b50-4f75-b845-925f5cdcfcf7.png width=150 />
  - Metamaskがない場合
<img src=https://user-images.githubusercontent.com/88795879/191187997-12279d7a-0800-46da-b576-415f20f4790a.png width=150 /><img src=https://user-images.githubusercontent.com/88795879/191190063-d3117ba4-a4d8-4066-ac55-4ea68bf6be1d.png width=150 />
### 備考
- 下記、別途タスクにて対応
  - 他のアプリ使用をなくすことはできるか