### PR TITLE
URLコピーにおけるUX改善

### DIFF
--- a/lib/src/components/modal_wallet_web_page.dart
+++ b/lib/src/components/modal_wallet_web_page.dart
@@ -4,28 +4,50 @@ import 'package:walletconnect_qrcode_modal_dart/src/lib/app_clipbord_manager.dar
 const _webAuthurl = 'https://app.cnpowners.jp';
 const _appGray = Color(0xFFA2A5A9);
 
-class ModalWalletWebPage extends StatelessWidget {
+class ModalWalletWebPage extends StatefulWidget {
   final Function() onPressed;
   const ModalWalletWebPage({
     required this.onPressed,
     Key? key,
   }) : super(key: key);
 
+  @override
+  State<ModalWalletWebPage> createState() => _ModalWalletWebPageState();
+}
+
+class _ModalWalletWebPageState extends State<ModalWalletWebPage> {
+  bool _copiedToClipboard = false;
+
   Widget _urlText(BuildContext context) {
-    return GestureDetector(
-      onTap: () => AppClipboardManager.copy(context, text: _webAuthurl),
+    return Padding(
+      padding: const EdgeInsets.only(left: 16),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: const [
-          Text(
+        children: [
+          const Text(
             _webAuthurl,
-            style: TextStyle(color: _appGray),
+            style: TextStyle(fontSize: 14, color: _appGray),
           ),
-          SizedBox(width: 8),
-          Icon(
-            Icons.content_copy,
-            size: 16,
-            color: _appGray,
+          const SizedBox(width: 8),
+          TextButton(
+            style: TextButton.styleFrom(
+              backgroundColor: _appGray.withOpacity(0.1),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              _copiedToClipboard ? 'Copied' : 'Copy',
+              style: const TextStyle(fontSize: 12, color: _appGray),
+            ),
+            onPressed: _copiedToClipboard
+                ? null
+                : () async {
+                    await AppClipboardManager.copy(context, text: _webAuthurl);
+                    setState(() => _copiedToClipboard = true);
+                    await Future.delayed(
+                      const Duration(seconds: 1),
+                      () => setState(() => _copiedToClipboard = false),
+                    );
+                  },
           ),
         ],
       ),
@@ -37,7 +59,7 @@ class ModalWalletWebPage extends StatelessWidget {
       width: double.infinity,
       child: TextButton(
         child: const Text('QRコードを読み込む'),
-        onPressed: onPressed,
+        onPressed: widget.onPressed,
         style: ButtonStyle(
           padding: MaterialStateProperty.all(
               const EdgeInsets.symmetric(vertical: 16, horizontal: 16)),


### PR DESCRIPTION
## 内容
Web認証におけるURLコピーが完了したかを明確にするため、TextButtonに変更
## UI
### iOS

https://user-images.githubusercontent.com/88795879/192578273-c0ebf96c-86f7-4c13-b4a5-837791331654.MP4

### android
<img src=https://user-images.githubusercontent.com/88795879/192578403-9d24f939-8abb-4082-98ee-fdd028aefc7d.png width=200 />
