### PR TITLE
Fix URLを中央寄せ

### DIFF
--- a/lib/src/components/modal_wallet_web_page.dart
+++ b/lib/src/components/modal_wallet_web_page.dart
@@ -19,38 +19,36 @@ class _ModalWalletWebPageState extends State<ModalWalletWebPage> {
   bool _copiedToClipboard = false;
 
   Widget _urlText(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
-      child: Row(
-        children: [
-          const Text(
-            _webAuthurl,
-            style: TextStyle(fontSize: 14, color: _appGray),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text(
+          _webAuthurl,
+          style: TextStyle(fontSize: 14, color: _appGray),
+        ),
+        const SizedBox(width: 8),
+        TextButton(
+          style: TextButton.styleFrom(
+            backgroundColor: _appGray.withOpacity(0.1),
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
-          const SizedBox(width: 8),
-          TextButton(
-            style: TextButton.styleFrom(
-              backgroundColor: _appGray.withOpacity(0.1),
-              minimumSize: Size.zero,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            child: Text(
-              _copiedToClipboard ? 'Copied' : 'Copy',
-              style: const TextStyle(fontSize: 12, color: _appGray),
-            ),
-            onPressed: _copiedToClipboard
-                ? null
-                : () async {
-                    await AppClipboardManager.copy(context, text: _webAuthurl);
-                    setState(() => _copiedToClipboard = true);
-                    await Future.delayed(
-                      const Duration(seconds: 1),
-                      () => setState(() => _copiedToClipboard = false),
-                    );
-                  },
+          child: Text(
+            _copiedToClipboard ? 'Copied' : 'Copy',
+            style: const TextStyle(fontSize: 12, color: _appGray),
           ),
-        ],
-      ),
+          onPressed: _copiedToClipboard
+              ? null
+              : () async {
+                  await AppClipboardManager.copy(context, text: _webAuthurl);
+                  setState(() => _copiedToClipboard = true);
+                  await Future.delayed(
+                    const Duration(seconds: 1),
+                    () => setState(() => _copiedToClipboard = false),
+                  );
+                },
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
## 内容
- RowのmainAxisAlignment: MainAxisAlignment.centerで中央寄せ
## 背景
- 元の実装意図
  - コピーする際にURLが動かないようにするため
- ただデバイスによって中央にならないため、変更
## UI
### iOS

https://user-images.githubusercontent.com/88795879/192717163-772dfbea-53a3-4269-bc74-2d72dd359749.MP4

### android
<img src=https://user-images.githubusercontent.com/88795879/192717513-36228500-c642-420d-bff7-e43693f1fb7b.png width=200 />
