### PR TITLE
【fix】一部テキストのTextStyle崩れに対応／モーダルの中身をスクロールできるようにした

### DIFF
--- a/lib/src/components/modal_main_page.dart
+++ b/lib/src/components/modal_main_page.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/components/text_ui.dart';
 
 import '../utils/utils.dart';
 import 'modal_qrcode_page.dart';
@@ -160,17 +161,11 @@ class _Segment extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: SizedBox(
-        width: 100,
-        child: Text(
-          text,
-          textAlign: TextAlign.center,
-          style: const TextStyle(
-            fontSize: 15,
-            fontWeight: FontWeight.bold,
-            color: Colors.black,
-          ),
-        ),
-      ),
+          width: 100,
+          child: TextUI(
+            textString: text,
+            fontSize: 15.0,
+          )),
     );
   }
 }

--- a/lib/src/components/modal_qrcode_page.dart
+++ b/lib/src/components/modal_qrcode_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/components/text_ui.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/lib/config/cnp_app_color.dart';
 
 class ModalQrCodePage extends StatefulWidget {
@@ -27,23 +28,11 @@ class _ModalQrCodePageState extends State<ModalQrCodePage> {
       ),
       child: Column(
         children: [
-          const Text(
-            'WalletConnect対応のウォレットで',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-              color: CnpAppColor.black,
-            ),
+          const TextUI(
+            textString: 'WalletConnect対応のウォレットで',
           ),
-          const Text(
-            'QRコードをスキャン',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-              color: CnpAppColor.black,
-            ),
+          const TextUI(
+            textString: 'QRコードをスキャン',
           ),
           Expanded(
             child: Padding(
@@ -54,12 +43,10 @@ class _ModalQrCodePageState extends State<ModalQrCodePage> {
           SizedBox(
             width: 260,
             child: TextButton(
-              child: Text(
-                _copiedToClipboard ? 'コピーしました' : 'クリップボードにコピー',
-                style: const TextStyle(
-                  fontSize: 14,
-                  color: Colors.white,
-                ),
+              child: TextUI(
+                textString: _copiedToClipboard ? 'コピーしました' : 'クリップボードにコピー',
+                fontSize: 14.0,
+                fontColor: Colors.white,
               ),
               onPressed: _copiedToClipboard
                   ? null

--- a/lib/src/components/modal_qrcode_page.dart
+++ b/lib/src/components/modal_qrcode_page.dart
@@ -21,58 +21,59 @@ class _ModalQrCodePageState extends State<ModalQrCodePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        vertical: 32,
-        horizontal: 16,
-      ),
-      child: Column(
-        children: [
-          const TextUI(
-            textString: 'WalletConnect対応のウォレットで',
-          ),
-          const TextUI(
-            textString: 'QRコードをスキャン',
-          ),
-          Expanded(
-            child: Padding(
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: 32,
+          horizontal: 16,
+        ),
+        child: Column(
+          children: [
+            const TextUI(
+              textString: 'WalletConnect対応のウォレットで',
+            ),
+            const TextUI(
+              textString: 'QRコードをスキャン',
+            ),
+            Padding(
               padding: const EdgeInsets.symmetric(vertical: 14),
-              child: QrImage(data: widget.uri),
+              child: QrImage(size: 220.0, data: widget.uri),
             ),
-          ),
-          SizedBox(
-            width: 260,
-            child: TextButton(
-              child: TextUI(
-                textString: _copiedToClipboard ? 'コピーしました' : 'クリップボードにコピー',
-                fontSize: 14.0,
-                fontColor: Colors.white,
-              ),
-              onPressed: _copiedToClipboard
-                  ? null
-                  : () async {
-                      await Clipboard.setData(ClipboardData(text: widget.uri));
-                      setState(() => _copiedToClipboard = true);
-                      await Future.delayed(const Duration(seconds: 1),
-                          () => setState(() => _copiedToClipboard = false));
-                    },
-              style: ButtonStyle(
-                padding: MaterialStateProperty.all(
-                    const EdgeInsets.symmetric(vertical: 16, horizontal: 16)),
-                shape: MaterialStateProperty.all(
-                  RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(40)),
+            SizedBox(
+              width: 260,
+              child: TextButton(
+                child: TextUI(
+                  textString: _copiedToClipboard ? 'コピーしました' : 'クリップボードにコピー',
+                  fontSize: 14.0,
+                  fontColor: Colors.white,
                 ),
-                foregroundColor:
-                    MaterialStateProperty.resolveWith((states) => Colors.white),
-                backgroundColor: MaterialStateProperty.resolveWith(
-                    (states) => CnpAppColor.black),
-                overlayColor: MaterialStateProperty.resolveWith(
-                    (states) => Colors.white.withOpacity(0.1)),
+                onPressed: _copiedToClipboard
+                    ? null
+                    : () async {
+                        await Clipboard.setData(
+                            ClipboardData(text: widget.uri));
+                        setState(() => _copiedToClipboard = true);
+                        await Future.delayed(const Duration(seconds: 1),
+                            () => setState(() => _copiedToClipboard = false));
+                      },
+                style: ButtonStyle(
+                  padding: MaterialStateProperty.all(
+                      const EdgeInsets.symmetric(vertical: 16, horizontal: 16)),
+                  shape: MaterialStateProperty.all(
+                    RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(40)),
+                  ),
+                  foregroundColor: MaterialStateProperty.resolveWith(
+                      (states) => Colors.white),
+                  backgroundColor: MaterialStateProperty.resolveWith(
+                      (states) => CnpAppColor.black),
+                  overlayColor: MaterialStateProperty.resolveWith(
+                      (states) => Colors.white.withOpacity(0.1)),
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/components/modal_wallet_android_page.dart
+++ b/lib/src/components/modal_wallet_android_page.dart
@@ -1,8 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/components/modal_main_page.dart';
-import 'package:walletconnect_qrcode_modal_dart/src/lib/config/cnp_app_color.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/components/text_ui.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/models/wallet.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/store/wallet_store.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/utils/utils.dart';
@@ -34,14 +33,8 @@ class ModalWalletAndroidPage extends StatelessWidget {
                   bottom: 24,
                   left: 16,
                 ),
-                child: Text(
-                  'ウォレットを選択',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.bold,
-                    color: CnpAppColor.black,
-                  ),
+                child: TextUI(
+                  textString: 'ウォレットを選択',
                 ),
               ),
               Expanded(
@@ -108,12 +101,10 @@ class ModalWalletAndroidPage extends StatelessWidget {
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16),
-                child: Text(
-                  wallet.name,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+                child: TextUI(
+                  textString: wallet.name,
+                  fontSize: 18.0,
+                  textAlign: TextAlign.start,
                 ),
               ),
             ),

--- a/lib/src/components/modal_wallet_desktop_page.dart
+++ b/lib/src/components/modal_wallet_desktop_page.dart
@@ -1,7 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:walletconnect_qrcode_modal_dart/src/lib/config/cnp_app_color.dart';
-
+import 'package:walletconnect_qrcode_modal_dart/src/components/text_ui.dart';
 import '../components/modal_main_page.dart';
 import '../models/wallet.dart';
 import '../store/wallet_store.dart';
@@ -34,14 +33,8 @@ class ModalWalletDesktopPage extends StatelessWidget {
                   bottom: 24,
                   left: 16,
                 ),
-                child: Text(
-                  'ウォレットを選択',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.bold,
-                    color: CnpAppColor.black,
-                  ),
+                child: TextUI(
+                  textString: 'ウォレットを選択',
                 ),
               ),
               Expanded(
@@ -63,12 +56,10 @@ class ModalWalletDesktopPage extends StatelessWidget {
                                 child: Padding(
                                   padding:
                                       const EdgeInsets.symmetric(vertical: 16),
-                                  child: Text(
-                                    wallet.name,
-                                    style: const TextStyle(
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.bold,
-                                    ),
+                                  child: TextUI(
+                                    textString: wallet.name,
+                                    fontSize: 18.0,
+                                    textAlign: TextAlign.start,
                                   ),
                                 ),
                               ),

--- a/lib/src/components/modal_wallet_ios_page.dart
+++ b/lib/src/components/modal_wallet_ios_page.dart
@@ -1,7 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:walletconnect_qrcode_modal_dart/src/lib/config/cnp_app_color.dart';
-
+import 'package:walletconnect_qrcode_modal_dart/src/components/text_ui.dart';
 import '../components/modal_main_page.dart';
 import '../models/wallet.dart';
 import '../store/wallet_store.dart';
@@ -34,14 +33,8 @@ class ModalWalletIOSPage extends StatelessWidget {
                   bottom: 24,
                   left: 16,
                 ),
-                child: Text(
-                  'ウォレットを選択',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: CnpAppColor.black,
-                  ),
+                child: TextUI(
+                  textString: 'ウォレットを選択',
                 ),
               ),
               Expanded(
@@ -108,12 +101,10 @@ class ModalWalletIOSPage extends StatelessWidget {
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16),
-                child: Text(
-                  wallet.name,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+                child: TextUI(
+                  textString: wallet.name,
+                  fontSize: 18.0,
+                  textAlign: TextAlign.start,
                 ),
               ),
             ),

--- a/lib/src/components/modal_wallet_web_page.dart
+++ b/lib/src/components/modal_wallet_web_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/components/text_ui.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/lib/app_clipbord_manager.dart';
 import 'package:walletconnect_qrcode_modal_dart/src/lib/config/cnp_app_color.dart';
 
@@ -23,20 +24,22 @@ class _ModalWalletWebPageState extends State<ModalWalletWebPage> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        const Text(
-          _webAuthurl,
-          style: TextStyle(fontSize: 14, color: _appGray),
+        const TextUI(
+          textString: _webAuthurl,
+          fontSize: 14.0,
+          fontColor: _appGray,
         ),
-        const SizedBox(width: 8),
+        const SizedBox(width: 12),
         TextButton(
           style: TextButton.styleFrom(
             backgroundColor: _appGray.withOpacity(0.1),
             minimumSize: Size.zero,
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
-          child: Text(
-            _copiedToClipboard ? 'Copied' : 'Copy',
-            style: const TextStyle(fontSize: 12, color: _appGray),
+          child: TextUI(
+            textString: _copiedToClipboard ? 'Copied' : 'Copy',
+            fontSize: 12.0,
+            fontColor: _appGray,
           ),
           onPressed: _copiedToClipboard
               ? null
@@ -57,12 +60,10 @@ class _ModalWalletWebPageState extends State<ModalWalletWebPage> {
     return SizedBox(
       width: 260,
       child: TextButton(
-        child: const Text(
-          'QRコードを読み込む',
-          style: TextStyle(
-            fontSize: 14,
-            color: Colors.white,
-          ),
+        child: const TextUI(
+          textString: 'QRコードを読み込む',
+          fontSize: 14.0,
+          fontColor: Colors.white,
         ),
         onPressed: widget.onPressed,
         style: ButtonStyle(
@@ -92,21 +93,22 @@ class _ModalWalletWebPageState extends State<ModalWalletWebPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          const Text(
-            '接続の手順',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-              color: CnpAppColor.black,
-            ),
+          const TextUI(
+            textString: '接続の手順',
           ),
           const SizedBox(height: 24),
-          const Text('1. PCで以下のリンクを開きMetaMaskと接続'),
+          const TextUI(
+            textString: '1. PCで以下のリンクを開きMetaMaskと接続',
+            fontSize: 14.0,
+          ),
           const SizedBox(height: 16),
           _urlText(context),
           const SizedBox(height: 24),
-          const Text('2. 接続後、生成されるQRコードを読み込む'),
-          const SizedBox(height: 16),
+          const TextUI(
+            textString: '2. 接続後、生成されるQRコードを読み込む',
+            fontSize: 14.0,
+          ),
+          const SizedBox(height: 24),
           _qrScannerButton(context)
         ],
       ),

--- a/lib/src/components/modal_wallet_web_page.dart
+++ b/lib/src/components/modal_wallet_web_page.dart
@@ -85,32 +85,34 @@ class _ModalWalletWebPageState extends State<ModalWalletWebPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        vertical: 32,
-        horizontal: 16,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const TextUI(
-            textString: '接続の手順',
-          ),
-          const SizedBox(height: 24),
-          const TextUI(
-            textString: '1. PCで以下のリンクを開きMetaMaskと接続',
-            fontSize: 14.0,
-          ),
-          const SizedBox(height: 16),
-          _urlText(context),
-          const SizedBox(height: 24),
-          const TextUI(
-            textString: '2. 接続後、生成されるQRコードを読み込む',
-            fontSize: 14.0,
-          ),
-          const SizedBox(height: 24),
-          _qrScannerButton(context)
-        ],
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: 32,
+          horizontal: 16,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const TextUI(
+              textString: '接続の手順',
+            ),
+            const SizedBox(height: 24),
+            const TextUI(
+              textString: '1. PCで以下のリンクを開きMetaMaskと接続',
+              fontSize: 14.0,
+            ),
+            const SizedBox(height: 16),
+            _urlText(context),
+            const SizedBox(height: 24),
+            const TextUI(
+              textString: '2. 接続後、生成されるQRコードを読み込む',
+              fontSize: 14.0,
+            ),
+            const SizedBox(height: 24),
+            _qrScannerButton(context),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/components/text_ui.dart
+++ b/lib/src/components/text_ui.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:walletconnect_qrcode_modal_dart/src/lib/config/cnp_app_color.dart';
+
+class TextUI extends StatelessWidget {
+  final String textString;
+  final double fontSize;
+  final Color fontColor;
+  final TextAlign textAlign;
+  const TextUI({
+    Key? key,
+    required this.textString,
+    this.fontSize = 16.0,
+    this.fontColor = CnpAppColor.black,
+    this.textAlign = TextAlign.center,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      textString,
+      textAlign: textAlign,
+      style: TextStyle(
+        fontSize: fontSize,
+        color: fontColor,
+        fontWeight: FontWeight.bold,
+        decoration: TextDecoration.none,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要
以下の問題に対処しました。

> フォントが存在しない的な挙動にみえる？
> スクロールも対応したい

<img width="440" alt="image-1" src="https://user-images.githubusercontent.com/61624152/203199651-402db0e4-a873-43e5-ab15-be21350898e0.png">

[bucket-cnp - Slack](https://anycloudhq.slack.com/files/UKF2TNGPP/F04BWP1L0UU/image-1.png)

## 対応内容
1 - プロジェクト内の全てのTextウィジェットをコンポーネントで共通化し
Styleを適用する事でFlutterのDefaultTextStyleが適用されてしまわないように対処

上記の参考記事
[Flutter の Text 、赤文字に黄色のアンダーラインってなんなの？ - Qiita](https://qiita.com/kurararara/items/2afd7f93f2676c5cee34)

> 実はこの派手なテーマは、 DefaultTextStyle クラスのデフォルト値のようです。
> シンプルに Text を利用している際はきれいに表示されていても、ダイアログなどを始め、他のウィジェットでラップした場合などにこのテーマで表示されてしまうことが 稀によくあります 。

2 - webタブ・QRコードタブ内部にもスクロールをつけた

## 動作確認（動画）

その1 - スクロールがわかるように（動作確認用に）中身を増やしたもの

https://user-images.githubusercontent.com/61624152/203200138-6d94ce0a-fbd3-49cb-ae9d-e5a20fd25daa.mov


その2 - 実際の完成形

https://user-images.githubusercontent.com/61624152/203200155-721e7eae-24c1-4b5e-b4a1-4bb357ac50ae.mov

## マージ後にやること
sns_appのpubspec.yamlの参照先のコミット（ref）を変更してPRをなげる