### PR TITLE
アプリが存在する場合アプリ内webで開くようにする

### DIFF
--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -21,18 +21,20 @@ class Utils {
   }) =>
       Uri.parse('$appLink/wc?uri=${Uri.encodeComponent(wcUri)}');
 
+  // アプリがインストールされている場合、native linkを優先して開く
+  // アプリがインストールされていない場合、universal linkをApp内webで開く
   static Future<void> iosLaunch({
     required Wallet wallet,
     required String uri,
   }) async {
-    if (await openableLink(wallet.mobile.universal)) {
-      await launchUrl(
-        convertToWcLink(appLink: wallet.mobile.universal!, wcUri: uri),
-        mode: LaunchMode.externalApplication,
-      );
-    } else if (await openableLink(wallet.mobile.native)) {
+    if (await openableLink(wallet.mobile.native)) {
       await launchUrl(
         convertToWcLink(appLink: wallet.mobile.native!, wcUri: uri),
+        mode: LaunchMode.externalApplication,
+      );
+    } else if (await openableLink(wallet.mobile.universal)) {
+      await launchUrl(
+        convertToWcLink(appLink: wallet.mobile.universal!, wcUri: uri),
       );
     } else if (await openableLink(wallet.app.ios)) {
       await launchUrl(Uri.parse(wallet.app.ios!));


### PR DESCRIPTION
## 変更概要
以下の要件を満たせるよう修正しました
- アプリがインストールされている場合はアプリを直接開く（mode: LaunchMode.externalApplication）
- アプリがインストールされていない場合App内webで開く

canLaunchUrl(uri) で指定されているuriが https://metamask.app.link/ なのでMetamaskアプリをインストールしているかどうかを判定してるんじゃなくてブラウザがあるか（https://~のリンクを開けるアプリがあるかどうか）をチェックしてるだけでした。なので、アプリが入っているかどうかを確認するにはwallet.mobile.native（=metamask://）を最初に確認しmetamaskアプリが入っているかどうかを確認する必要がありました。なので条件式を入れ替えています

## 動作確認

https://github.com/anycloud-inc/walletconnect_qrcode_modal_dart/assets/82256596/2f7c0b33-5dcd-4069-aa26-df4ba500d426

